### PR TITLE
Fix merging of ranges

### DIFF
--- a/src/range/merge.js
+++ b/src/range/merge.js
@@ -1,20 +1,31 @@
 // This function takes in an array of number pairs and combines where there's overlap
 module.exports = function mergeRanges(ranges) {
   const numberOfRanges = ranges.length;
+
   if (numberOfRanges > 0) {
-    const firstRange = ranges[0];
-    let previousEnd = firstRange[1];
-    const result = [firstRange];
+    // Sort ranges by start, and if equal, by end
+    ranges.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+
+    const result = [];
+    let [currentStart, currentEnd] = ranges[0];
+
     for (let i = 1; i < numberOfRanges; i++) {
-      const tempRange = ranges[i];
-      const [start, end] = tempRange;
-      if (start <= previousEnd) {
-        result[result.length - 1][1] = end;
+      const [start, end] = ranges[i];
+
+      // If the current range overlaps or is contiguous with the previous one
+      if (start <= currentEnd) {
+        currentEnd = Math.max(currentEnd, end); // Extend the range
       } else {
-        result.push(tempRange);
+        // Push the current range to the result and start a new one
+        result.push([currentStart, currentEnd]);
+        currentStart = start;
+        currentEnd = end;
       }
-      previousEnd = end;
     }
+
+    // Push the last range
+    result.push([currentStart, currentEnd]);
+
     return result;
   }
 };

--- a/test.js
+++ b/test.js
@@ -1,18 +1,18 @@
-const fs = require("fs");
+const fs = require('fs');
 
-const test = require("flug");
+const test = require('flug');
 
-const findAndRead = require("find-and-read");
-const getPreciseBoundingBox = require("geotiff-precise-bbox");
-const from = require("geotiff-from");
-const reprojectGeoJSON = require("reproject-geojson");
-const count = require("fast-counter");
-const writePng = require("@danieljdufour/write-png");
-const { clip, prepareData, transform, update } = require("xdim");
+const findAndRead = require('find-and-read');
+const getPreciseBoundingBox = require('geotiff-precise-bbox');
+const from = require('geotiff-from');
+const reprojectGeoJSON = require('reproject-geojson');
+const count = require('fast-counter');
+const writePng = require('@danieljdufour/write-png');
+const { clip, prepareData, transform, update } = require('xdim');
 
 const clone = it => JSON.parse(JSON.stringify(it));
 
-const loadVector = fp => JSON.parse(findAndRead(fp, { encoding: "utf-8" }));
+const loadVector = fp => JSON.parse(findAndRead(fp, { encoding: 'utf-8' }));
 
 const getPolygons = it => {
   const polygons = [];
@@ -28,7 +28,10 @@ const get_most_common = arr => {
 };
 
 const writeImage = (filename, data, [width, height]) => {
-  writePng(`./test-output/${filename.replaceAll(" ", "_")}`, data, { width, height });
+  writePng(`./test-output/${filename.replaceAll(' ', '_')}`, data, {
+    width,
+    height,
+  });
 };
 
 const {
@@ -48,10 +51,10 @@ const {
   rangeCut,
   rangeOverlap,
   roundDown,
-  rangeSort
-} = require("./src/index.js");
+  rangeSort,
+} = require('./src/index.js');
 
-test("edge case: global box", ({ eq }) => {
+test('edge case: global box', ({ eq }) => {
   calculate({
     debug_level: 0,
     raster_bbox: [-180, -90, 180, 90],
@@ -65,83 +68,83 @@ test("edge case: global box", ({ eq }) => {
         [179.95833333333334, -89.95833333333333],
         [179.95833333333334, 89.95833333333333],
         [-179.95833333333334, 89.95833333333333],
-        [-179.95833333333334, -89.95833333333333]
-      ]
-    ]
+        [-179.95833333333334, -89.95833333333333],
+      ],
+    ],
   });
 });
 
-test("carveHoles", ({ eq }) => {
+test('carveHoles', ({ eq }) => {
   eq(
     carveHoles(
       [
         [0, 10],
-        [50, 100]
+        [50, 100],
       ],
       []
     ),
     [
       [0, 10],
-      [50, 100]
+      [50, 100],
     ]
   );
   eq(
     carveHoles(
       [
         [0, 10],
-        [50, 100]
+        [50, 100],
       ],
       [[11, 49]]
     ),
     [
       [0, 10],
-      [50, 100]
+      [50, 100],
     ]
   );
   eq(
     carveHoles(
       [
         [0, 10],
-        [50, 100]
+        [50, 100],
       ],
       [[10, 49]]
     ),
     [
       [0, 9],
-      [50, 100]
+      [50, 100],
     ]
   );
   eq(
     carveHoles(
       [
         [0, 10],
-        [50, 100]
+        [50, 100],
       ],
       [[10, 50]]
     ),
     [
       [0, 9],
-      [51, 100]
+      [51, 100],
     ]
   );
   eq(
     carveHoles(
       [
         [0, 10],
-        [50, 100]
+        [50, 100],
       ],
       [[5, 75]]
     ),
     [
       [0, 4],
-      [76, 100]
+      [76, 100],
     ]
   );
   eq(
     carveHoles(
       [
         [0, 10],
-        [50, 100]
+        [50, 100],
       ],
       [[5, 200]]
     ),
@@ -149,27 +152,27 @@ test("carveHoles", ({ eq }) => {
   );
 });
 
-test("rangeCut", ({ eq }) => {
+test('rangeCut', ({ eq }) => {
   eq(rangeCut([0, 100], [101, 200]), [[0, 100]]);
   eq(rangeCut([0, 100], [100, 200]), [[0, 99]]);
   eq(rangeCut([0, 100], [50, 200]), [[0, 49]]);
   eq(rangeCut([0, 100], [50, 99]), [
     [0, 49],
-    [100, 100]
+    [100, 100],
   ]);
   eq(rangeCut([0, 100], [0, 100]), []);
   eq(rangeCut([0, 100], [-1, 101]), []);
   eq(rangeCut([403, 584], [509, 514]), [
     [403, 508],
-    [515, 584]
+    [515, 584],
   ]);
   eq(rangeCut([403, 584], [501, 501]), [
     [403, 500],
-    [502, 584]
+    [502, 584],
   ]);
 });
 
-test("rangeOverlap", ({ eq }) => {
+test('rangeOverlap', ({ eq }) => {
   eq(rangeOverlap([1, 2], [3, 4]), false);
   eq(rangeOverlap([1, 2], [2, 3]), true);
   eq(rangeOverlap([1, 2], [1, 1]), true);
@@ -177,32 +180,32 @@ test("rangeOverlap", ({ eq }) => {
   eq(rangeOverlap([1, 2], [1, 3]), true);
 });
 
-test("rangeSort", ({ eq }) => {
+test('rangeSort', ({ eq }) => {
   eq(
     rangeSort([
       [78, 10],
       [78, 5],
       [1, 2],
       [3, 4],
-      [4, 5]
+      [4, 5],
     ]),
     [
       [1, 2],
       [3, 4],
       [4, 5],
       [78, 5],
-      [78, 10]
+      [78, 10],
     ]
   );
 });
 
-test("eachPair", ({ eq }) => {
+test('eachPair', ({ eq }) => {
   const coords = [
     [78, 10],
     [78, 5],
     [82, 5],
     [82, 10],
-    [78, 10]
+    [78, 10],
   ];
   const actual = [];
   eachPair(coords, (pair, ipair) => actual.push([ipair, pair]));
@@ -211,34 +214,34 @@ test("eachPair", ({ eq }) => {
       0,
       [
         [78, 10],
-        [78, 5]
-      ]
+        [78, 5],
+      ],
     ],
     [
       1,
       [
         [78, 5],
-        [82, 5]
-      ]
+        [82, 5],
+      ],
     ],
     [
       2,
       [
         [82, 5],
-        [82, 10]
-      ]
+        [82, 10],
+      ],
     ],
     [
       3,
       [
         [82, 10],
-        [78, 10]
-      ]
-    ]
+        [78, 10],
+      ],
+    ],
   ]);
 });
 
-test("roundDown", ({ eq }) => {
+test('roundDown', ({ eq }) => {
   eq(roundDown(0), 0);
   eq(roundDown(-0.5), -1);
   eq(roundDown(-10.49), -10);
@@ -246,7 +249,7 @@ test("roundDown", ({ eq }) => {
   eq(roundDown(1.5), 1);
 });
 
-test("prepareSnap", ({ eq }) => {
+test('prepareSnap', ({ eq }) => {
   const snap = prepareSnap(0, 5);
   eq(snap([-4.5, 5]), [-1, 1]);
   eq(snap([-2.5, 5]), [-1, 1]);
@@ -259,14 +262,14 @@ test("prepareSnap", ({ eq }) => {
   eq(snap([15, 20]), [3, 4]);
 });
 
-test("partition", ({ eq }) => {
+test('partition', ({ eq }) => {
   const nums = [0, 1, 2, 3];
   const [even, odd] = partition(nums, n => n % 2 === 0);
   eq(even, [0, 2]);
   eq(odd, [1, 3]);
 });
 
-test("categorization of intersections", ({ eq }) => {
+test('categorization of intersections', ({ eq }) => {
   // through
   let segments = [{ xmin: -140, xmax: -140, direction: 1 }];
   let actual = categorizeIntersection(segments);
@@ -277,7 +280,7 @@ test("categorization of intersections", ({ eq }) => {
   // rebound
   segments = [
     { xmin: -140, xmax: -140, direction: 1 },
-    { xmin: -140, xmax: -140, direction: -1 }
+    { xmin: -140, xmax: -140, direction: -1 },
   ];
   actual = categorizeIntersection(segments);
   eq(actual.through, false);
@@ -288,7 +291,7 @@ test("categorization of intersections", ({ eq }) => {
   segments = [
     { xmin: -140, xmax: -140, direction: 1 },
     { xmin: -140, xmax: -130, direction: 0 },
-    { xmin: -130, xmax: -130, direction: 1 }
+    { xmin: -130, xmax: -130, direction: 1 },
   ];
   actual = categorizeIntersection(segments);
   eq(actual.through, true);
@@ -299,7 +302,7 @@ test("categorization of intersections", ({ eq }) => {
   segments = [
     { xmin: -140, xmax: -140, direction: 1 },
     { xmin: -140, xmax: -130, direction: 0 },
-    { xmin: -130, xmax: -130, direction: -1 }
+    { xmin: -130, xmax: -130, direction: -1 },
   ];
   actual = categorizeIntersection(segments);
   eq(actual.through, false);
@@ -309,7 +312,7 @@ test("categorization of intersections", ({ eq }) => {
   // through with stop
   segments = [
     { xmin: -140, xmax: -140, direction: 1 },
-    { xmin: -140, xmax: -140, direction: 1 }
+    { xmin: -140, xmax: -140, direction: 1 },
   ];
   actual = categorizeIntersection(segments);
   eq(actual.through, true);
@@ -317,17 +320,27 @@ test("categorization of intersections", ({ eq }) => {
   eq(actual.xmax, -140);
 });
 
-test("clustering", ({ eq }) => {
+test('clustering', ({ eq }) => {
   let segments, computed, computedNumberOfClusters;
 
-  segments = [{ endsOffLine: true }, { endsOffLine: false }, { endsOffLine: false }, { endsOffLine: true }];
+  segments = [
+    { endsOffLine: true },
+    { endsOffLine: false },
+    { endsOffLine: false },
+    { endsOffLine: true },
+  ];
   computed = cluster(segments, s => s.endsOffLine);
   computedNumberOfClusters = computed.length;
   eq(computedNumberOfClusters, 2);
   eq(computed[0].length, 1);
   eq(computed[1].length, 3);
 
-  segments = [{ endsOffLine: true, index: 0 }, { endsOffLine: false }, { endsOffLine: false }, { endsOffLine: false, index: 99 }];
+  segments = [
+    { endsOffLine: true, index: 0 },
+    { endsOffLine: false },
+    { endsOffLine: false },
+    { endsOffLine: false, index: 99 },
+  ];
   computed = cluster(segments, s => s.endsOffLine);
   computedNumberOfClusters = computed.length;
   eq(computedNumberOfClusters, 2);
@@ -335,12 +348,17 @@ test("clustering", ({ eq }) => {
   eq(computed[1].length, 3);
 });
 
-test("clustering of line segments", ({ eq }) => {
+test('clustering of line segments', ({ eq }) => {
   const segments = [
     { endsOffLine: true, index: 0 },
     { endsOffLine: false },
     { endsOffLine: false },
-    { endsOffLine: false, endsOnLine: true, last_edge_in_ring: true, index: 99 }
+    {
+      endsOffLine: false,
+      endsOnLine: true,
+      last_edge_in_ring: true,
+      index: 99,
+    },
   ];
   const computed = clusterLineSegments(segments, true);
   computedNumberOfClusters = computed.length;
@@ -348,7 +366,7 @@ test("clustering of line segments", ({ eq }) => {
   eq(computed[0].length, 4);
 });
 
-test("coupling", ({ eq }) => {
+test('coupling', ({ eq }) => {
   const items = [0, 1, 18, 77, 99, 103];
   const actual = couple(items);
   eq(actual.length, items.length / 2);
@@ -357,37 +375,46 @@ test("coupling", ({ eq }) => {
   });
 });
 
-test("clamping", ({ eq }) => {
+test('clamping', ({ eq }) => {
   eq(clamp(10, 1, 11), 10);
   eq(clamp(-10, 1, 11), 1);
   eq(clamp(990, 1, 11), 11);
 });
 
-test("merging of index ranges", ({ eq }) => {
+test('merging of index ranges', ({ eq }) => {
   let original = [
     [0, 10],
     [10, 10],
     [20, 30],
-    [30, 40]
+    [30, 40],
   ];
   let merged = mergeRanges(original);
-  eq(JSON.stringify(merged), "[[0,10],[20,40]]");
+  eq(JSON.stringify(merged), '[[0,10],[20,40]]');
 
   original = [
     [0, 10],
     [10, 10],
     [21, 31],
-    [30, 40]
+    [30, 40],
   ];
   merged = mergeRanges(original);
-  eq(JSON.stringify(merged), "[[0,10],[21,40]]");
+  eq(JSON.stringify(merged), '[[0,10],[21,40]]');
+
+  original = [
+    [-6, -2],
+    [-10, -2],
+    [0, 12],
+  ];
+
+  merged = mergeRanges(original);
+  eq(JSON.stringify(merged), '[[-10,-2],[0,12]]');
 });
 
-test("merging of consecutive ranges", ({ eq }) => {
+test('merging of consecutive ranges', ({ eq }) => {
   eq(
     mergeConsecutiveRanges([
       [0, 5],
-      [1, 4]
+      [1, 4],
     ]),
     [[0, 5]]
   );
@@ -398,11 +425,11 @@ test("merging of consecutive ranges", ({ eq }) => {
       [3, 10],
       [11, 15],
       [20, 30],
-      [27, 28]
+      [27, 28],
     ]),
     [
       [0, 15],
-      [20, 30]
+      [20, 30],
     ]
   );
 
@@ -411,17 +438,17 @@ test("merging of consecutive ranges", ({ eq }) => {
       [0, 5],
       [0, 10],
       [21, 31],
-      [30, 40]
+      [30, 40],
     ]),
     [
       [0, 10],
-      [21, 40]
+      [21, 40],
     ]
   );
 });
 
-test("get polygons for Akrotiri and Dhekelia", async ({ eq }) => {
-  const geojson = loadVector("Akrotiri and Dhekelia.geojson");
+test('get polygons for Akrotiri and Dhekelia', async ({ eq }) => {
+  const geojson = loadVector('Akrotiri and Dhekelia.geojson');
   const polygons = getPolygons(geojson);
   eq(polygons.length, 2); // number of polygons
   eq(polygons[0].length, 1); // number of rings in first polygon
@@ -430,12 +457,12 @@ test("get polygons for Akrotiri and Dhekelia", async ({ eq }) => {
     [32.84080886840826, 34.699466705322436],
     [32.84599304199236, 34.699466705322436],
     [32.853767395019645, 34.699466705322436],
-    [32.859687805175724, 34.70057678222679]
+    [32.859687805175724, 34.70057678222679],
   ]);
 });
 
-test("get polygons for Sri Lanka", async ({ eq }) => {
-  const geojson = loadVector("sri-lanka.geojson");
+test('get polygons for Sri Lanka', async ({ eq }) => {
+  const geojson = loadVector('sri-lanka.geojson');
   const polygons = getPolygons(geojson);
   eq(polygons.length, 1); // number of polygons
   eq(polygons[0].length, 1); // number of rings in first polygon
@@ -451,15 +478,15 @@ test("get polygons for Sri Lanka", async ({ eq }) => {
         [80.14780073437964, 9.824077663609557],
         [80.83881798698656, 9.268426825391188],
         [81.30431928907177, 8.56420624433369],
-        [81.7879590188914, 7.523055324733164]
-      ]
-    ]
+        [81.7879590188914, 7.523055324733164],
+      ],
+    ],
   ]);
 });
 
-test("calculate intersection of Sri-Lanka with GeoTIFF", async ({ eq }) => {
+test('calculate intersection of Sri-Lanka with GeoTIFF', async ({ eq }) => {
   // same crs as geojson
-  const arrayBuffer = await findAndRead("gadas-export-4326.tif");
+  const arrayBuffer = await findAndRead('gadas-export-4326.tif');
   const geotiff = await from(arrayBuffer);
   const image = await geotiff.getImage();
   const precise_bbox = getPreciseBoundingBox(image);
@@ -472,9 +499,9 @@ test("calculate intersection of Sri-Lanka with GeoTIFF", async ({ eq }) => {
   const pixel_width = Math.abs(resolutionX);
   const pixel_height = Math.abs(resolutionY);
 
-  const geojson = loadVector("sri-lanka.geojson");
+  const geojson = loadVector('sri-lanka.geojson');
 
-  const MOST_COMMON_VALUE = "65,65,67,255";
+  const MOST_COMMON_VALUE = '65,65,67,255';
 
   let minRow = Infinity;
   let maxRow = -Infinity;
@@ -502,32 +529,35 @@ test("calculate intersection of Sri-Lanka with GeoTIFF", async ({ eq }) => {
         clip({
           data: raster_values,
           flat: true,
-          layout: "[band][row,column]",
+          layout: '[band][row,column]',
           rect: {
             band: [0, 3],
             column: [columnIndex, columnIndex],
-            row: [rowIndex, rowIndex]
+            row: [rowIndex, rowIndex],
           },
-          sizes
-        }).data.join(",")
+          sizes,
+        }).data.join(',')
       );
       update({
         data: raster_values,
-        layout: "[band][row,column]",
+        layout: '[band][row,column]',
         point: {
           band: 3,
           row: rowIndex,
-          column: columnIndex
+          column: columnIndex,
         },
         sizes,
-        value: 0
+        value: 0,
       });
-    }
+    },
   });
 
   eq(get_most_common(values)[0], MOST_COMMON_VALUE);
 
-  writeImage("gadas-export-4326-sri-lanka", raster_values, [raster_width, raster_height]);
+  writeImage('gadas-export-4326-sri-lanka', raster_values, [
+    raster_width,
+    raster_height,
+  ]);
 
   const EXPECTED_MIN_ROW = 91;
   const EXPECTED_MAX_ROW = 266;
@@ -545,7 +575,10 @@ test("calculate intersection of Sri-Lanka with GeoTIFF", async ({ eq }) => {
   const xmin = Number(precise_bbox[0]);
   const ymin = Number(precise_bbox[1]);
   for (let i = 0; i < polygon.length; i++) {
-    polygon[i] = polygon[i].map(([x, y]) => [(x - xmin) / pixel_width, (y - ymin) / pixel_height]);
+    polygon[i] = polygon[i].map(([x, y]) => [
+      (x - xmin) / pixel_width,
+      (y - ymin) / pixel_height,
+    ]);
   }
 
   // reset
@@ -567,7 +600,7 @@ test("calculate intersection of Sri-Lanka with GeoTIFF", async ({ eq }) => {
       if (rowIndex > maxRow) maxRow = rowIndex;
       if (columnIndex < minCol) minCol = columnIndex;
       if (columnIndex > maxCol) maxCol = columnIndex;
-    }
+    },
   });
 
   eq(minRow, EXPECTED_MIN_ROW);
@@ -576,10 +609,13 @@ test("calculate intersection of Sri-Lanka with GeoTIFF", async ({ eq }) => {
   eq(maxCol, EXPECTED_MAX_COL);
 });
 
-test("validate ranges", ({ eq }) => {
-  ["sri-lanka.geojson", "sri-lanka-hires.geojson"].forEach(filename => {
+test('validate ranges', ({ eq }) => {
+  ['sri-lanka.geojson', 'sri-lanka-hires.geojson'].forEach(filename => {
     const result = calculate({
-      raster_bbox: [69.15892987765864, 1.4662483490272988, 90.42846112765297, 11.81870408668788],
+      raster_bbox: [
+        69.15892987765864, 1.4662483490272988, 90.42846112765297,
+        11.81870408668788,
+      ],
       raster_height: 475,
       raster_width: 968,
       pixel_height: 0.0217946436582328,
@@ -588,9 +624,9 @@ test("validate ranges", ({ eq }) => {
       per_row_segment: ({ row, columns }) => {
         const [start, end] = columns;
         if (start > end) {
-          throw new Error("uh oh. in row", row, "range", columns);
+          throw new Error('uh oh. in row', row, 'range', columns);
         }
-      }
+      },
     });
     eq(result.rows.length, 475);
     result.rows.forEach(row => {
@@ -600,25 +636,31 @@ test("validate ranges", ({ eq }) => {
   });
 });
 
-test("geometry larger than raster", ({ eq }) => {
+test('geometry larger than raster', ({ eq }) => {
   const result = calculate({
     // tile within the united states
-    raster_bbox: [-11271133.50845855, 4381155.514617654, -10640325.58387179, 5012277.581474598],
+    raster_bbox: [
+      -11271133.50845855, 4381155.514617654, -10640325.58387179,
+      5012277.581474598,
+    ],
     raster_height: 256,
     raster_width: 256,
     pixel_height: 2465.3205736599375,
     pixel_width: 2464.0934554170312,
-    geometry: reprojectGeoJSON(loadVector("usa.geojson"), { from: 4326, to: 3857 }),
+    geometry: reprojectGeoJSON(loadVector('usa.geojson'), {
+      from: 4326,
+      to: 3857,
+    }),
     per_row_segment: ({ row, columns }) => {
       try {
         const [start, end] = columns;
         eq(start <= end, true);
       } catch (error) {
-        console.log("row:", row);
-        console.log("columns:", columns);
+        console.log('row:', row);
+        console.log('columns:', columns);
         throw error;
       }
-    }
+    },
   });
   result.rows.forEach(segs => {
     segs.forEach(([start, end]) => {
@@ -627,25 +669,30 @@ test("geometry larger than raster", ({ eq }) => {
   });
 });
 
-test("geometry extends beyond left edge of raster", ({ eq }) => {
+test('geometry extends beyond left edge of raster', ({ eq }) => {
   const result = calculate({
     // tile covers east of united states
-    raster_bbox: [-10018754.171394622, -7.081154551613622e-10, 0, 10018754.171394624],
+    raster_bbox: [
+      -10018754.171394622, -7.081154551613622e-10, 0, 10018754.171394624,
+    ],
     raster_height: 256,
     raster_width: 256,
     pixel_height: 39135.75848201025,
     pixel_width: 39135.75848201024,
-    geometry: reprojectGeoJSON(loadVector("usa.geojson", "utf-8"), { from: 4326, to: 3857 }),
+    geometry: reprojectGeoJSON(loadVector('usa.geojson', 'utf-8'), {
+      from: 4326,
+      to: 3857,
+    }),
     per_row_segment: ({ row, columns }) => {
       try {
         const [start, end] = columns;
         eq(start <= end, true);
       } catch (error) {
-        console.log("row:", row);
-        console.log("columns:", columns);
+        console.log('row:', row);
+        console.log('columns:', columns);
         throw error;
       }
-    }
+    },
   });
   result.rows.forEach(segs => {
     segs.forEach(([start, end]) => {
@@ -654,12 +701,12 @@ test("geometry extends beyond left edge of raster", ({ eq }) => {
   });
 });
 
-test("rectangular hole", ({ eq }) => {
+test('rectangular hole', ({ eq }) => {
   const data = [
     [0, 0, 0, 0],
     [0, 0, 0, 0],
     [0, 0, 0, 0],
-    [0, 0, 0, 0]
+    [0, 0, 0, 0],
   ];
 
   let pixel_count = 0;
@@ -675,37 +722,39 @@ test("rectangular hole", ({ eq }) => {
     pixel_height: 5,
     pixel_width: 5,
     geometry: {
-      type: "Feature",
+      type: 'Feature',
       properties: {},
       geometry: {
-        type: "Polygon",
+        type: 'Polygon',
         coordinates: [
           [
             [0, 0],
             [20, 0],
             [20, 20],
             [0, 20],
-            [0, 0]
+            [0, 0],
           ],
           [
             [5, 5],
             [5, 15],
             [15, 15],
             [15, 5],
-            [5, 5]
-          ]
-        ]
+            [5, 5],
+          ],
+        ],
       },
-      bbox: [0, 0, 20, 20]
-    }
+      bbox: [0, 0, 20, 20],
+    },
   });
   eq(pixel_count, 12);
-  writeImage("rect-hole", [data, data, data], [4, 4]);
+  writeImage('rect-hole', [data, data, data], [4, 4]);
 });
 
-test("holes: overlapping", async ({ eq }) => {
+test('holes: overlapping', async ({ eq }) => {
   // same crs as geojson
-  const arrayBuffer = await findAndRead("spam2005v3r2_harvested-area_wheat_total.tiff");
+  const arrayBuffer = await findAndRead(
+    'spam2005v3r2_harvested-area_wheat_total.tiff'
+  );
   const geotiff = await from(arrayBuffer);
   const image = await geotiff.getImage();
   const precise_bbox = getPreciseBoundingBox(image);
@@ -723,10 +772,15 @@ test("holes: overlapping", async ({ eq }) => {
   // rescale to 0-255, note: min value is zero
   band = Array.from(band).map(n => (n < 0 ? 0 : Math.round((255 * n) / 11752)));
 
-  const raster_values = [clone(band), clone(band), clone(band), new Array(band.length).fill(255)];
+  const raster_values = [
+    clone(band),
+    clone(band),
+    clone(band),
+    new Array(band.length).fill(255),
+  ];
 
   // geojson with box and hole cut out for Sri Lanka
-  const geojson = loadVector("overlapping.geojson");
+  const geojson = loadVector('overlapping.geojson');
 
   let count = 0;
 
@@ -742,21 +796,21 @@ test("holes: overlapping", async ({ eq }) => {
       [255, 255, 0].forEach((value, bandIndex) => {
         update({
           data: raster_values,
-          layout: "[band][row,column]",
+          layout: '[band][row,column]',
           point: {
             band: bandIndex,
             row: rowIndex,
-            column: columnIndex
+            column: columnIndex,
           },
           sizes: {
             band: 4,
             row: raster_height,
-            column: raster_width
+            column: raster_width,
           },
-          value
+          value,
         });
       });
-    }
+    },
   });
 
   // set nodata to -1, so we get a count of all pixels including no data
@@ -764,12 +818,12 @@ test("holes: overlapping", async ({ eq }) => {
   // 10655
   eq(count, 2260800);
 
-  writeImage("overlapping", raster_values, [raster_width, raster_height]);
+  writeImage('overlapping', raster_values, [raster_width, raster_height]);
 });
 
-test("self-contained holes", async ({ eq }) => {
+test('self-contained holes', async ({ eq }) => {
   // same crs as geojson
-  const arrayBuffer = await findAndRead("gadas-export-4326.tif");
+  const arrayBuffer = await findAndRead('gadas-export-4326.tif');
   const geotiff = await from(arrayBuffer);
   const raster_values = await geotiff.readRasters();
   const image = await geotiff.getImage();
@@ -783,7 +837,7 @@ test("self-contained holes", async ({ eq }) => {
   const pixel_height = Math.abs(resolutionY);
 
   // geojson with box and hole cut out for Sri Lanka
-  const geojson = loadVector("contained.geojson");
+  const geojson = loadVector('contained.geojson');
 
   let minRow = Infinity;
   let maxRow = -Infinity;
@@ -805,20 +859,20 @@ test("self-contained holes", async ({ eq }) => {
       // hide raster values, by setting 4th band value to zero
       update({
         data: raster_values,
-        layout: "[band][row,column]",
+        layout: '[band][row,column]',
         point: {
           band: 3,
           row: rowIndex,
-          column: columnIndex
+          column: columnIndex,
         },
         sizes: {
           band: 4,
           row: raster_height,
-          column: raster_width
+          column: raster_width,
         },
-        value: 0
+        value: 0,
       });
-    }
+    },
   });
   const EXPECTED_MIN_ROW = 83;
   const EXPECTED_MAX_ROW = 310;
@@ -830,12 +884,12 @@ test("self-contained holes", async ({ eq }) => {
   eq(minCol, EXPECTED_MIN_COL);
   eq(maxCol, EXPECTED_MAX_COL);
 
-  writeImage("hole-contained", raster_values, [raster_width, raster_height]);
+  writeImage('hole-contained', raster_values, [raster_width, raster_height]);
 });
 
-test("hole support: Sri Lanka test case", async ({ eq }) => {
+test('hole support: Sri Lanka test case', async ({ eq }) => {
   // same crs as geojson
-  const arrayBuffer = await findAndRead("gadas-export-4326.tif");
+  const arrayBuffer = await findAndRead('gadas-export-4326.tif');
   const geotiff = await from(arrayBuffer);
   const raster_values = await geotiff.readRasters();
   const image = await geotiff.getImage();
@@ -849,7 +903,7 @@ test("hole support: Sri Lanka test case", async ({ eq }) => {
   const pixel_height = Math.abs(resolutionY);
 
   // geojson with box and hole cut out for Sri Lanka
-  const geojson = loadVector("hole.geojson");
+  const geojson = loadVector('hole.geojson');
 
   let minRow = Infinity;
   let maxRow = -Infinity;
@@ -871,20 +925,20 @@ test("hole support: Sri Lanka test case", async ({ eq }) => {
       // hide raster values, by setting 4th band value to zero
       update({
         data: raster_values,
-        layout: "[band][row,column]",
+        layout: '[band][row,column]',
         point: {
           band: 3,
           row: rowIndex,
-          column: columnIndex
+          column: columnIndex,
         },
         sizes: {
           band: 4,
           row: raster_height,
-          column: raster_width
+          column: raster_width,
         },
-        value: 0
+        value: 0,
       });
-    }
+    },
   });
   const EXPECTED_MIN_ROW = 83;
   const EXPECTED_MAX_ROW = 310;
@@ -896,12 +950,12 @@ test("hole support: Sri Lanka test case", async ({ eq }) => {
   eq(minCol, EXPECTED_MIN_COL);
   eq(maxCol, EXPECTED_MAX_COL);
 
-  writeImage("hole", raster_values, [raster_width, raster_height]);
+  writeImage('hole', raster_values, [raster_width, raster_height]);
 });
 
-test("Akrotiri and Dhekelia", async ({ eq }) => {
+test('Akrotiri and Dhekelia', async ({ eq }) => {
   // same crs as geojson
-  const arrayBuffer = await findAndRead("gadas-cyprus.tif");
+  const arrayBuffer = await findAndRead('gadas-cyprus.tif');
   const geotiff = await from(arrayBuffer);
   const raster_values = await geotiff.readRasters();
   const image = await geotiff.getImage();
@@ -915,7 +969,7 @@ test("Akrotiri and Dhekelia", async ({ eq }) => {
   const pixel_height = Math.abs(resolutionY);
 
   // geojson with box and hole cut out for Sri Lanka
-  const geojson = loadVector("Akrotiri and Dhekelia.geojson");
+  const geojson = loadVector('Akrotiri and Dhekelia.geojson');
 
   let count = 0;
 
@@ -931,31 +985,36 @@ test("Akrotiri and Dhekelia", async ({ eq }) => {
       [0, 255, 0].forEach((value, bandIndex) => {
         update({
           data: raster_values,
-          layout: "[band][row,column]",
+          layout: '[band][row,column]',
           point: {
             band: bandIndex,
             row: rowIndex,
-            column: columnIndex
+            column: columnIndex,
           },
           sizes: {
             band: 4,
             row: raster_height,
-            column: raster_width
+            column: raster_width,
           },
-          value
+          value,
         });
       });
-    }
+    },
   });
 
   eq(count, 818);
 
-  writeImage("Akrotiri and Dhekelia", raster_values, [raster_width, raster_height]);
+  writeImage('Akrotiri and Dhekelia', raster_values, [
+    raster_width,
+    raster_height,
+  ]);
 });
 
-test("countries", async ({ eq }) => {
+test('countries', async ({ eq }) => {
   // same crs as geojson
-  const arrayBuffer = await findAndRead("spam2005v3r2_harvested-area_wheat_total.tiff");
+  const arrayBuffer = await findAndRead(
+    'spam2005v3r2_harvested-area_wheat_total.tiff'
+  );
   const geotiff = await from(arrayBuffer);
   const image = await geotiff.getImage();
   const precise_bbox = getPreciseBoundingBox(image);
@@ -973,24 +1032,29 @@ test("countries", async ({ eq }) => {
   // rescale to 0-255, note: min value is zero
   band = Array.from(band).map(n => (n < 0 ? 0 : Math.round((255 * n) / 11752)));
 
-  const raster_values = [clone(band), clone(band), clone(band), new Array(band.length).fill(255)];
+  const raster_values = [
+    clone(band),
+    clone(band),
+    clone(band),
+    new Array(band.length).fill(255),
+  ];
 
   [
     // set nodata to -1, so we get a count of all pixels including no data
     // pipenv run sh -c "fio cat ./data/geojson-test-data/gadm/afghanistan.geojson | rio zonalstats -r ./data/spam2005v3r2_harvested-area_wheat_total.tiff --nodata -1 --stats count | jq .features[0].properties._count"
-    ["Afghanistan", 9027], // rasterstats says 9029
-    ["Akrotiri and Dhekelia", null],
-    ["Croatia", 916], // rasterstats says 935
-    ["Cyprus", 81],
-    ["Jamaica", 133], // rasterstats says 134
-    ["Lebanon", 145],
-    ["Macedonia", 383],
-    ["Nicaragua", 1531], // rasterstats says 1536
-    ["Ukraine", 10644], // rasterstats says 10655
-    ["Uruguay", 2461] // rasterstats says 2462
+    ['Afghanistan', 9027], // rasterstats says 9029
+    ['Akrotiri and Dhekelia', null],
+    ['Croatia', 916], // rasterstats says 935
+    ['Cyprus', 81],
+    ['Jamaica', 133], // rasterstats says 134
+    ['Lebanon', 145],
+    ['Macedonia', 383],
+    ['Nicaragua', 1531], // rasterstats says 1536
+    ['Ukraine', 10644], // rasterstats says 10655
+    ['Uruguay', 2461], // rasterstats says 2462
   ].forEach(([country, expected_count]) => {
     // geojson with box and hole cut out for Sri Lanka
-    const geojson = loadVector(country + ".geojson");
+    const geojson = loadVector(country + '.geojson');
 
     let count = 0;
 
@@ -1006,25 +1070,25 @@ test("countries", async ({ eq }) => {
         [0, 255, 0].forEach((value, bandIndex) => {
           update({
             data: raster_values,
-            layout: "[band][row,column]",
+            layout: '[band][row,column]',
             point: {
               band: bandIndex,
               row: rowIndex,
-              column: columnIndex
+              column: columnIndex,
             },
             sizes: {
               band: 4,
               row: raster_height,
-              column: raster_width
+              column: raster_width,
             },
-            value
+            value,
           });
         });
-      }
+      },
     });
 
     if (expected_count !== null) eq(count, expected_count);
   });
 
-  writeImage("countries", raster_values, [raster_width, raster_height]);
+  writeImage('countries', raster_values, [raster_width, raster_height]);
 });


### PR DESCRIPTION
This should hopefully address the issues described in issue #5.

In the case described in the issue `mergeRanges` receives 
```javascript
[[-6038.525234528924, -20489.502785170105], [-158989.0188331666, -20489.502785170105]]
```
and incorrectly returns
```javascript
[[-6038.525234528924, -20489.502785170105]]
```
because it assumes that the ranges are always in ascending order.

By first sorting the ranges it returns the original ranges without any merging, and this allows the row to render correctly:
```javascript
[[-158989.0188331666,  -20489.502785170105], [-6038.525234528924, -6038.525234528924]]
```